### PR TITLE
Add influenza, pfizer pediátrica e coronavac pediátrica

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ Todos os Enums estão disponíveis para uso atráves da interface príncipal do 
     - `Immunizing.ASTRAZENECA`
     - `Immunizing.INTERCAMBIALIDADE`
     - `Immunizing.PFIZER`
+    - `Immunizing.PFIZER_PEDIATRICA`
     - `Immunizing.CORONAVAC`
     - `Immunizing.JANSSEN`
     - `Immunizing.INFLUENZA`

--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ Todos os Enums estão disponíveis para uso atráves da interface príncipal do 
     - `Immunizing.PFIZER`
     - `Immunizing.PFIZER_PEDIATRICA`
     - `Immunizing.CORONAVAC`
+    - `Immunizing.CORONAVAC_PEDIATRICA`
     - `Immunizing.JANSSEN`
     - `Immunizing.INFLUENZA`
 

--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ Todos os Enums estão disponíveis para uso atráves da interface príncipal do 
     - `Immunizing.PFIZER`
     - `Immunizing.CORONAVAC`
     - `Immunizing.JANSSEN`
+    - `Immunizing.INFLUENZA`
 
 
 ## Contribuições

--- a/filometro/__init__.py
+++ b/filometro/__init__.py
@@ -16,7 +16,7 @@ __all__ = [
     'District',
     'Filometro'
 ]
-__version__ = '0.1.1'
+__version__ = '0.2.0'
 __author__ = 'Matheus Felipe'
 
 from filometro.enums import Zone

--- a/filometro/convert.py
+++ b/filometro/convert.py
@@ -29,6 +29,7 @@ def posto_dict_to_posto_object(posto_dict: dict) -> Posto:
         coronavac=posto_dict['coronavac'],
         pfizer=posto_dict['pfizer'],
         janssen=posto_dict['janssen'],
+        influenza=posto_dict['influenza'],
         intercambialidade=posto_dict['intercambialidade'],
         situation=posto_dict['status_fila'],
         modality=posto_dict['tipo_posto'],

--- a/filometro/convert.py
+++ b/filometro/convert.py
@@ -28,6 +28,7 @@ def posto_dict_to_posto_object(posto_dict: dict) -> Posto:
         astrazeneca=posto_dict['astrazeneca'],
         coronavac=posto_dict['coronavac'],
         pfizer=posto_dict['pfizer'],
+        pfizer_pediatrica=posto_dict['pfizer_ped'],
         janssen=posto_dict['janssen'],
         influenza=posto_dict['influenza'],
         intercambialidade=posto_dict['intercambialidade'],

--- a/filometro/convert.py
+++ b/filometro/convert.py
@@ -27,6 +27,7 @@ def posto_dict_to_posto_object(posto_dict: dict) -> Posto:
         zone=posto_dict['crs'],
         astrazeneca=posto_dict['astrazeneca'],
         coronavac=posto_dict['coronavac'],
+        coronavac_pediatrica=posto_dict['corona_ped'],
         pfizer=posto_dict['pfizer'],
         pfizer_pediatrica=posto_dict['pfizer_ped'],
         janssen=posto_dict['janssen'],

--- a/filometro/dataclasses.py
+++ b/filometro/dataclasses.py
@@ -24,6 +24,7 @@ class Posto():
     astrazeneca: str = field(repr=False)
     coronavac: str = field(repr=False)
     pfizer: str = field(repr=False)
+    pfizer_pediatrica: str = field(repr=False)
     janssen: str = field(repr=False)
     influenza: str = field(repr=False)
     intercambialidade: str = field(repr=False)

--- a/filometro/dataclasses.py
+++ b/filometro/dataclasses.py
@@ -25,6 +25,7 @@ class Posto():
     coronavac: str = field(repr=False)
     pfizer: str = field(repr=False)
     janssen: str = field(repr=False)
+    influenza: str = field(repr=False)
     intercambialidade: str = field(repr=False)
     situation: str = field(repr=False)           # status_fila
     modality: str = field(repr=False)            # tipo_posto

--- a/filometro/dataclasses.py
+++ b/filometro/dataclasses.py
@@ -23,6 +23,7 @@ class Posto():
     zone: str = field(repr=False)                # crs (Coordinate Reference Systems)
     astrazeneca: str = field(repr=False)
     coronavac: str = field(repr=False)
+    coronavac_pediatrica: str = field(repr=False)
     pfizer: str = field(repr=False)
     pfizer_pediatrica: str = field(repr=False)
     janssen: str = field(repr=False)

--- a/filometro/enums.py
+++ b/filometro/enums.py
@@ -51,6 +51,7 @@ class Immunizing(Enum):
     PFIZER = 'pfizer'
     CORONAVAC = 'coronavac'
     JANSSEN = 'janssen'
+    INFLUENZA = 'influenza'
 
 
 class District(Enum):

--- a/filometro/enums.py
+++ b/filometro/enums.py
@@ -49,6 +49,7 @@ class Immunizing(Enum):
     ASTRAZENECA = 'astrazeneca'
     INTERCAMBIALIDADE = 'intercambialidade'
     PFIZER = 'pfizer'
+    PFIZER_PEDIATRICA = 'pfizer_pediatrica'
     CORONAVAC = 'coronavac'
     JANSSEN = 'janssen'
     INFLUENZA = 'influenza'

--- a/filometro/enums.py
+++ b/filometro/enums.py
@@ -51,6 +51,7 @@ class Immunizing(Enum):
     PFIZER = 'pfizer'
     PFIZER_PEDIATRICA = 'pfizer_pediatrica'
     CORONAVAC = 'coronavac'
+    CORONAVAC_PEDIATRICA = 'coronavac_pediatrica'
     JANSSEN = 'janssen'
     INFLUENZA = 'influenza'
 


### PR DESCRIPTION
Suporte para os novos imunizantes disponíveis no site.

resolve #4, #5 e #6 